### PR TITLE
xinetd added to Vagrantfile and manage_dns set to 0

### DIFF
--- a/Licence.txt
+++ b/Licence.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-EOF
     yum -y update
     yum -y install epel-release
-    yum -y install cobbler cobbler-web dhcp syslinux pykickstart
+    yum -y install cobbler cobbler-web dhcp syslinux pykickstart xinetd
+    systemctl enable xinetd.service
     systemctl enable cobblerd
     systemctl enable httpd
     systemctl enable dhcpd
@@ -36,6 +37,7 @@ Vagrant.configure(2) do |config|
     sed -i -e 's/SELINUX=enforcing/SELINUX=disabled/' /etc/selinux/config
     setenforce 0
     setsebool -P httpd_can_network_connect true
+    systemctl start xinetd.service
     systemctl start cobblerd
     systemctl start httpd
     cobbler get-loaders

--- a/etc/cobbler/dhcp.template
+++ b/etc/cobbler/dhcp.template
@@ -19,6 +19,7 @@ set vendorclass = option vendor-class-identifier;
 option pxe-system-type code 93 = unsigned integer 16;
 
 subnet 192.168.56.0 netmask 255.255.255.0 {
+     deny unknown-clients;
      option routers             192.168.56.5;
      option domain-name-servers 192.168.56.1;
      option subnet-mask         255.255.255.0;

--- a/etc/cobbler/settings
+++ b/etc/cobbler/settings
@@ -244,7 +244,7 @@ manage_dhcp: 1
 
 # set to 1 to enable Cobbler's DNS management features.
 # the choice of DNS mangement engine is in /etc/cobbler/modules.conf
-manage_dns: 1
+manage_dns: 0
 
 # set to path of bind chroot to create bind-chroot compatible bind
 # configuration files.  This should be automatically detected.


### PR DESCRIPTION
The tftp service was not started automatically as the xinetd service was missing from Vagrantfile's provisioning.
The dns is now disabled as the named service is not configured to be installed and will fail the cobbler sync task.
