### PR TITLE
added xinetd to Dockerfile & Vagrantfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 VOLUME [ “/sys/fs/cgroup” ]
 
 RUN yum -y install epel-release
-RUN yum -y install cobbler cobbler-web dhcp bind syslinux pykickstart
+RUN yum -y install cobbler cobbler-web dhcp bind syslinux pykickstart xinetd
 
-RUN systemctl enable cobblerd httpd dhcpd
+RUN systemctl enable cobblerd httpd dhcpd xinetd
 
 # enable tftp
 RUN sed -i -e 's/\(^.*disable.*=\) yes/\1 no/' /etc/xinetd.d/tftp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,10 +28,11 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-EOF
     yum -y update
     yum -y install epel-release
-    yum -y install cobbler cobbler-web dhcp syslinux pykickstart
+    yum -y install cobbler cobbler-web dhcp syslinux pykickstart xinetd
     systemctl enable cobblerd
     systemctl enable httpd
     systemctl enable dhcpd
+    systemctl enable xinetd
     sed -i -e 's/\(^.*disable.*=\) yes/\1 no/' /etc/xinetd.d/tftp
     sed -i -e 's/SELINUX=enforcing/SELINUX=disabled/' /etc/selinux/config
     setenforce 0


### PR DESCRIPTION
It turned out that xinetd is not in centos:7.2.1511 by default. Anyway it's better to make sure it's installed and enabled.