### PR TITLE
Remove the --net as ports are already exposed Fix #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ run:
 	@docker run \
 	  -d \
 	  --privileged \
-	  --net host \
 	  -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	  -v $(shell pwd)/etc/cobbler/settings:/etc/cobbler/settings \
 	  -v $(shell pwd)/etc/cobbler/dhcp.template:/etc/cobbler/dhcp.template \


### PR DESCRIPTION
Removing --net, ports are already exposed. Also using  the docker hosted environment on the MAC does not work.  